### PR TITLE
Refactor Only - No Functional Changes

### DIFF
--- a/feature_cop.gemspec
+++ b/feature_cop.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'activesupport', '~> 4.2'
-  spec.add_development_dependency "bundler", "~> 1.11"
+  spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
 end

--- a/feature_cop.gemspec
+++ b/feature_cop.gemspec
@@ -14,6 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "http://www.github.com/nuvi/feature_cop"
   spec.license       = "MIT"
 
+  spec.required_ruby_version = '> 2.0.0'
+
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }

--- a/lib/feature_cop/blacklist.rb
+++ b/lib/feature_cop/blacklist.rb
@@ -18,9 +18,9 @@ module FeatureCop
         self.blacklist = ::YAML.load_file(absolute_path)[env]
       end
 
-      def all_except_blacklist(identifier)
+      def all_except_blacklist(feature, identifier, options = {})
         return true if @blacklist.nil?
-        !blacklisted?(identifier)
+        !blacklisted?(feature, identifier, options)
       end
 
       def blacklist
@@ -31,9 +31,9 @@ module FeatureCop
         @blacklist = blacklist
       end
 
-      def blacklisted?(identifier)
-        return false if @blacklist.nil?
-        @blacklist.include?(identifier)
+      def blacklisted?(feature, identifier, options = {})
+        return false if blacklist.nil?
+        blacklist.include?(identifier)
       end
     end
   end

--- a/lib/feature_cop/sampling.rb
+++ b/lib/feature_cop/sampling.rb
@@ -1,0 +1,28 @@
+module FeatureCop
+  module Sampling
+
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+      def sample10(feature, identifier, options = {})
+        return true if whitelisted?(feature, identifier, options)
+        return false if blacklisted?(feature, identifier, options)
+        identifier.bytes.sum % 10 == 0 
+      end
+
+      def sample30(feature, identifier, options = {})
+        return true if whitelisted?(feature, identifier, options)
+        return false if blacklisted?(feature, identifier, options)
+        identifier.bytes.sum % 3 == 0 
+      end
+
+      def sample50(feature, identifier, options = {})
+        return true if whitelisted?(feature, identifier, options)
+        return false if blacklisted?(feature, identifier, options)
+        identifier.bytes.sum.odd? 
+      end
+    end
+  end
+end

--- a/lib/feature_cop/toggle.rb
+++ b/lib/feature_cop/toggle.rb
@@ -1,0 +1,19 @@
+module FeatureCop
+  module Toggle
+
+    def self.included(base)
+      base.extend ClassMethods
+    end
+
+    module ClassMethods
+
+      def enabled(*args)
+        true
+      end
+
+      def disabled(*args)
+        false
+      end
+    end
+  end
+end

--- a/lib/feature_cop/whitelist.rb
+++ b/lib/feature_cop/whitelist.rb
@@ -26,13 +26,13 @@ module FeatureCop
         @whitelist = whitelist
       end
 
-      def whitelist_only(identifier)
-        whitelisted?(identifier)
+      def whitelist_only(feature, identifier, options = {})
+        whitelisted?(feature, identifier, options)
       end
 
-      def whitelisted?(identifier)
-        return false if @whitelist.nil?
-        @whitelist.include?(identifier)
+      def whitelisted?(feature, identifier, options = {})
+        return false if whitelist.nil?
+        whitelist.include?(identifier)
       end
     end
   end

--- a/test/blacklist_test.rb
+++ b/test/blacklist_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+
+class BlacklistTest < Minitest::Test
+  def test_blacklisted_features_are_false_when_they_are_in_the_black_list
+    ENV["BLACKLIST_FEATURE"] = "all_except_blacklist"
+    assert FeatureCop.allows?(:blacklist_feature, "BAD GUY")
+
+    FeatureCop.blacklist = ["BAD GUY"] 
+    refute FeatureCop.allows?(:blacklist_feature, "BAD GUY")
+    assert FeatureCop.allows?(:blacklist_feature, "GOOD_GUY")
+  end
+
+  def test_sample_features_are_exclude_blacklist_users
+    ENV["SAMPLE10_FEATURE"] = "sample10"
+    ENV["SAMPLE30_FEATURE"] = "sample30"
+    ENV["SAMPLE50_FEATURE"] = "sample50"
+
+    FeatureCop.blacklist = ["BAD_GUY"] 
+
+    refute FeatureCop.allows?(:sample10_feature, "BAD_GUY")
+    refute FeatureCop.allows?(:sample30_feature, "BAD_GUY")
+    refute FeatureCop.allows?(:sample50_feature, "BAD_GUY")
+  end
+
+  def test_blacklist_can_be_configured_from_yml
+    FeatureCop.blacklist_from_yaml(File.join(__dir__, "sample_access_list.yml"))
+    assert FeatureCop.blacklist.include?("user_1")
+  end
+end

--- a/test/blacklist_test.rb
+++ b/test/blacklist_test.rb
@@ -23,7 +23,8 @@ class BlacklistTest < Minitest::Test
   end
 
   def test_blacklist_can_be_configured_from_yml
-    FeatureCop.blacklist_from_yaml(File.join(__dir__, "sample_access_list.yml"))
+    current_directory = File.dirname(File.realpath(__FILE__))
+    FeatureCop.blacklist_from_yaml(File.join(current_directory, "sample_access_list.yml"))
     assert FeatureCop.blacklist.include?("user_1")
   end
 end

--- a/test/feature_cop_test.rb
+++ b/test/feature_cop_test.rb
@@ -21,24 +21,6 @@ class FeatureCopTest < Minitest::Test
     refute FeatureCop.allows?(:unidentified_feature, "SOME IDENTIFIER")
   end
 
-  def test_whitelisted_features_are_true_when_they_are_in_the_white_list
-    ENV["WHITELIST_FEATURE"] = "whitelist_only"
-    FeatureCop.whitelist = []
-    refute FeatureCop.allows?(:whitelist_feature, "GOOD_GUY")
-
-    FeatureCop.whitelist = ["GOOD_GUY"] 
-    assert FeatureCop.allows?(:whitelist_feature, "GOOD_GUY")
-  end
-
-  def test_blacklisted_features_are_false_when_they_are_in_the_black_list
-    ENV["BLACKLIST_FEATURE"] = "all_except_blacklist"
-    assert FeatureCop.allows?(:blacklist_feature, "BAD GUY")
-
-    FeatureCop.blacklist = ["BAD GUY"] 
-    refute FeatureCop.allows?(:blacklist_feature, "BAD GUY")
-    assert FeatureCop.allows?(:blacklist_feature, "GOOD_GUY")
-  end
-
   def test_sample10_features_are_true_for_roughly_ten_percent_of_users
     ENV["SAMPLE10_FEATURE"] = "sample10"
 
@@ -78,31 +60,6 @@ class FeatureCopTest < Minitest::Test
     assert  true_count < 560
   end
 
-  def test_sample_features_are_include_whitelisted_users
-    ENV["SAMPLE10_FEATURE"] = "sample10"
-    ENV["SAMPLE30_FEATURE"] = "sample30"
-    ENV["SAMPLE50_FEATURE"] = "sample50"
-
-    FeatureCop.whitelist = ["GOOD_GUY"] 
-
-    assert FeatureCop.allows?(:sample10_feature, "GOOD_GUY")
-    assert FeatureCop.allows?(:sample30_feature, "GOOD_GUY")
-    assert FeatureCop.allows?(:sample50_feature, "GOOD_GUY")
-  end
-
-
-  def test_sample_features_are_exclude_blacklist_users
-    ENV["SAMPLE10_FEATURE"] = "sample10"
-    ENV["SAMPLE30_FEATURE"] = "sample30"
-    ENV["SAMPLE50_FEATURE"] = "sample50"
-
-    FeatureCop.blacklist = ["BAD_GUY"] 
-
-    refute FeatureCop.allows?(:sample10_feature, "BAD_GUY")
-    refute FeatureCop.allows?(:sample30_feature, "BAD_GUY")
-    refute FeatureCop.allows?(:sample50_feature, "BAD_GUY")
-  end
-
   def test_features_are_taken_from_env
     ENV["TEST_FEATURE"] = "enabled"
     FeatureCop.reset_features
@@ -120,15 +77,5 @@ class FeatureCopTest < Minitest::Test
     ENV["JSON_FEATURE"] = "sample50"
     FeatureCop.reset_features
     assert FeatureCop.to_json("d").include?("\"jsonFeature\":false")
-  end
-
-  def test_whitelist_can_be_configured_from_yml_with_custom_path
-    FeatureCop.whitelist_from_yaml(File.join(__dir__, "sample_access_list.yml"))
-    assert FeatureCop.whitelist.include?("user_1")
-  end
-
-  def test_blacklist_can_be_configured_from_yml
-    FeatureCop.blacklist_from_yaml(File.join(__dir__, "sample_access_list.yml"))
-    assert FeatureCop.blacklist.include?("user_1")
   end
 end

--- a/test/feature_cop_test.rb
+++ b/test/feature_cop_test.rb
@@ -6,60 +6,6 @@ class FeatureCopTest < Minitest::Test
     refute_nil ::FeatureCop::VERSION
   end
 
-  def test_enabled_features_are_always_true
-    ENV["RANDOM_FEATURE"] = "enabled"
-    assert FeatureCop.allows?(:random_feature, "SOME IDENTIFIER")
-    assert FeatureCop.allows?(:random_feature)
-  end
-
-  def test_disabled_features_are_always_false
-    ENV["RANDOM_FEATURE"] = "disabled"
-    refute FeatureCop.allows?(:random_feature, "SOME IDENTIFIER")
-  end
-
-  def test_unidentified_features_are_always_false
-    refute FeatureCop.allows?(:unidentified_feature, "SOME IDENTIFIER")
-  end
-
-  def test_sample10_features_are_true_for_roughly_ten_percent_of_users
-    ENV["SAMPLE10_FEATURE"] = "sample10"
-
-    true_count = 0
-
-    1000.times do |count|
-      true_count += 1 if FeatureCop.allows?(:sample10_feature, SecureRandom.hex)
-    end
-
-    assert  true_count  > 70, "Count: #{true_count} is less than 70"
-    assert  true_count < 130, "Count: #{true_count} is greater than 130"
-  end
-
-  def test_sample30_features_are_true_for_roughty_thirty_percent_of_users
-    ENV["SAMPLE30_FEATURE"] = "sample30"
-
-    true_count = 0
-
-    1000.times do |count|
-      true_count += 1 if FeatureCop.allows?(:sample30_feature, SecureRandom.hex)
-    end
-
-    assert  true_count  > 240, "Count: #{true_count} is less than 240"
-    assert  true_count  < 360, "Count: #{true_count} is greater than 360"
-  end
-
-  def test_sample50_features_are_true_for_roughly_50_percent_of_users
-    ENV["SAMPLE50_FEATURE"] = "sample50"
-
-    true_count = 0
-
-    1000.times do |count|
-      true_count += 1 if FeatureCop.allows?(:sample50_feature, SecureRandom.hex)
-    end
-
-    assert  true_count > 440
-    assert  true_count < 560
-  end
-
   def test_features_are_taken_from_env
     ENV["TEST_FEATURE"] = "enabled"
     FeatureCop.reset_features

--- a/test/sample_feature_list.yml
+++ b/test/sample_feature_list.yml
@@ -1,8 +1,0 @@
-development:
-  my_awesome_feature: enabled 
-
-stage:
-  my_awesome_feature: whitelist_only
-
-prod:
-  my_awesome_feature: disabled

--- a/test/sampling_test.rb
+++ b/test/sampling_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+
+class SamplingTest < Minitest::Test
+  def test_sample10_features_are_true_for_roughly_ten_percent_of_users
+    ENV["SAMPLE10_FEATURE"] = "sample10"
+
+    true_count = 0
+
+    1000.times do |count|
+      true_count += 1 if FeatureCop.allows?(:sample10_feature, SecureRandom.hex)
+    end
+
+    assert  true_count  > 70, "Count: #{true_count} is less than 70"
+    assert  true_count < 130, "Count: #{true_count} is greater than 130"
+  end
+
+  def test_sample30_features_are_true_for_roughty_thirty_percent_of_users
+    ENV["SAMPLE30_FEATURE"] = "sample30"
+
+    true_count = 0
+
+    1000.times do |count|
+      true_count += 1 if FeatureCop.allows?(:sample30_feature, SecureRandom.hex)
+    end
+
+    assert  true_count  > 240, "Count: #{true_count} is less than 240"
+    assert  true_count  < 360, "Count: #{true_count} is greater than 360"
+  end
+
+  def test_sample50_features_are_true_for_roughly_50_percent_of_users
+    ENV["SAMPLE50_FEATURE"] = "sample50"
+
+    true_count = 0
+
+    1000.times do |count|
+      true_count += 1 if FeatureCop.allows?(:sample50_feature, SecureRandom.hex)
+    end
+
+    assert  true_count > 440
+    assert  true_count < 560
+  end
+
+end

--- a/test/toggle_test.rb
+++ b/test/toggle_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class ToggleTest < Minitest::Test
+
+  def test_enabled_features_are_always_true
+    ENV["RANDOM_FEATURE"] = "enabled"
+    assert FeatureCop.allows?(:random_feature, "SOME IDENTIFIER")
+    assert FeatureCop.allows?(:random_feature)
+  end
+
+  def test_disabled_features_are_always_false
+    ENV["RANDOM_FEATURE"] = "disabled"
+    refute FeatureCop.allows?(:random_feature, "SOME IDENTIFIER")
+  end
+end

--- a/test/whitelist_test.rb
+++ b/test/whitelist_test.rb
@@ -25,7 +25,8 @@ class WhitelistTest < Minitest::Test
 
 
   def test_whitelist_can_be_configured_from_yml_with_custom_path
-    FeatureCop.whitelist_from_yaml(File.join(__dir__, "sample_access_list.yml"))
+    current_directory = File.dirname(File.realpath(__FILE__))
+    FeatureCop.whitelist_from_yaml(File.join(current_directory, "sample_access_list.yml"))
     assert FeatureCop.whitelist.include?("user_1")
   end
 

--- a/test/whitelist_test.rb
+++ b/test/whitelist_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+
+class WhitelistTest < Minitest::Test
+
+  def test_whitelisted_features_are_true_when_they_are_in_the_white_list
+    ENV["WHITELIST_FEATURE"] = "whitelist_only"
+    FeatureCop.whitelist = []
+    refute FeatureCop.allows?(:whitelist_feature, "GOOD_GUY")
+
+    FeatureCop.whitelist = ["GOOD_GUY"] 
+    assert FeatureCop.allows?(:whitelist_feature, "GOOD_GUY")
+  end
+
+  def test_sample_features_are_include_whitelisted_users
+    ENV["SAMPLE10_FEATURE"] = "sample10"
+    ENV["SAMPLE30_FEATURE"] = "sample30"
+    ENV["SAMPLE50_FEATURE"] = "sample50"
+
+    FeatureCop.whitelist = ["GOOD_GUY"] 
+
+    assert FeatureCop.allows?(:sample10_feature, "GOOD_GUY")
+    assert FeatureCop.allows?(:sample30_feature, "GOOD_GUY")
+    assert FeatureCop.allows?(:sample50_feature, "GOOD_GUY")
+  end
+
+
+  def test_whitelist_can_be_configured_from_yml_with_custom_path
+    FeatureCop.whitelist_from_yaml(File.join(__dir__, "sample_access_list.yml"))
+    assert FeatureCop.whitelist.include?("user_1")
+  end
+
+end


### PR DESCRIPTION
In anticipation of adding some new features, this changeset just refactors some things

* Move sampling functions to a Sampling modules (sample10, sample 30, sample 50)
* Move enabled / disabled functions to a Toggle module
* Pass through feature, identifier, and options from  the allows? method to all sub methods.  The methods should know the feature, identifier, and options anyway.  This was an oversight in the first implementation.
* Move tests out to other test files so they are just testing the modules.  Note: They are still testing the modules through the main feature cop api.

// @cavneb @nateastle @inlineblock  
