### PR TITLE
FAT-24 Add Support for Whitelist and Blacklist by specific feature

### DIFF
--- a/lib/feature_cop.rb
+++ b/lib/feature_cop.rb
@@ -21,7 +21,7 @@ module FeatureCop
   def self.allows?(feature, identifier = nil, options = {})
     feature_status = ENV["#{feature.to_s.upcase}"]
     return false if feature_status.nil? 
-    self.method(feature_status.downcase).call(feature, identifier, options)
+    self.method(feature_status.downcase).call(feature.to_s, identifier.to_s, options)
   end
 
   def self.env

--- a/lib/feature_cop/blacklist.rb
+++ b/lib/feature_cop/blacklist.rb
@@ -19,21 +19,26 @@ module FeatureCop
       end
 
       def all_except_blacklist(feature, identifier, options = {})
-        return true if @blacklist.nil?
+        return true if blacklist.nil?
         !blacklisted?(feature, identifier, options)
       end
 
       def blacklist
-        @blacklist 
+        @blacklist ||= {} 
       end
 
       def blacklist=(blacklist)
+        if blacklist.is_a?(Array)
+          @blacklist = { "default" => blacklist }
+          return
+        end
         @blacklist = blacklist
       end
 
       def blacklisted?(feature, identifier, options = {})
-        return false if blacklist.nil?
-        blacklist.include?(identifier)
+        feature = "default" if blacklist[feature].nil?
+        return false if blacklist[feature].nil?
+        blacklist[feature].include?(identifier)
       end
     end
   end

--- a/lib/feature_cop/whitelist.rb
+++ b/lib/feature_cop/whitelist.rb
@@ -19,10 +19,14 @@ module FeatureCop
       end
 
       def whitelist
-        @whitelist
+        @whitelist ||= {}
       end
 
       def whitelist=(whitelist)
+        if whitelist.is_a?(Array)
+          @whitelist = { "default" => whitelist }
+          return
+        end
         @whitelist = whitelist
       end
 
@@ -31,8 +35,9 @@ module FeatureCop
       end
 
       def whitelisted?(feature, identifier, options = {})
-        return false if whitelist.nil?
-        whitelist.include?(identifier)
+        feature = "default" if whitelist[feature].nil?
+        return false if whitelist[feature].nil?
+        whitelist[feature].include?(identifier)
       end
     end
   end

--- a/test/blacklist_test.rb
+++ b/test/blacklist_test.rb
@@ -25,6 +25,28 @@ class BlacklistTest < Minitest::Test
   def test_blacklist_can_be_configured_from_yml
     current_directory = File.dirname(File.realpath(__FILE__))
     FeatureCop.blacklist_from_yaml(File.join(current_directory, "sample_access_list.yml"))
-    assert FeatureCop.blacklist.include?("user_1")
+    assert FeatureCop.blacklist["default"].include?("user_1")
+  end
+
+  def test_blacklist_can_be_configured_from_yml_with_custom_path
+    ENV["SAMPLE10_FEATURE"] = "sample10"
+    current_directory = File.dirname(File.realpath(__FILE__))
+    FeatureCop.blacklist_from_yaml(File.join(current_directory, "sample_access_list.yml"))
+    assert FeatureCop.blacklist["default"].include?("user_1")
+    refute FeatureCop.allows?(:sample10_feature, "user_1")
+  end
+
+
+  def test_blacklist_configuration_can_include_multiple_features
+    ENV["FEATURE1"] = "all_except_blacklist"
+    ENV["FEATURE2"] = "all_except_blacklist"
+
+    current_directory = File.dirname(File.realpath(__FILE__))
+    FeatureCop.blacklist_from_yaml(File.join(current_directory, "sample_tiered_access_list.yml"))
+
+    refute FeatureCop.allows?(:feature1, "user_1")
+    refute FeatureCop.allows?(:feature1, "user_2")
+    refute FeatureCop.allows?(:feature2, "user_3")
+    refute FeatureCop.allows?(:feature2, "user_4")
   end
 end

--- a/test/sample_tiered_access_list.yml
+++ b/test/sample_tiered_access_list.yml
@@ -1,0 +1,12 @@
+development:
+  feature1:
+  - user_1
+  - user_2
+
+  feature2:
+  - user_3
+  - user_4
+
+stage:
+
+prod:

--- a/test/whitelist_test.rb
+++ b/test/whitelist_test.rb
@@ -25,9 +25,25 @@ class WhitelistTest < Minitest::Test
 
 
   def test_whitelist_can_be_configured_from_yml_with_custom_path
+    ENV["SAMPLE10_FEATURE"] = "sample10"
     current_directory = File.dirname(File.realpath(__FILE__))
     FeatureCop.whitelist_from_yaml(File.join(current_directory, "sample_access_list.yml"))
-    assert FeatureCop.whitelist.include?("user_1")
+    assert FeatureCop.whitelist["default"].include?("user_1")
+    assert FeatureCop.allows?(:sample10_feature, "user_1")
+  end
+
+
+  def test_whitelist_configuration_can_include_multiple_features
+    ENV["FEATURE1"] = "whitelist_only"
+    ENV["FEATURE2"] = "whitelist_only"
+
+    current_directory = File.dirname(File.realpath(__FILE__))
+    FeatureCop.whitelist_from_yaml(File.join(current_directory, "sample_tiered_access_list.yml"))
+
+    assert FeatureCop.allows?(:feature1, "user_1")
+    assert FeatureCop.allows?(:feature1, "user_2")
+    assert FeatureCop.allows?(:feature2, "user_3")
+    assert FeatureCop.allows?(:feature2, "user_4")
   end
 
 end


### PR DESCRIPTION
FAT-24
This allows users to configure a whitelist or a blacklist by feature.

Example Usage


```yml
development:
  feature1:
    - DEV_USER_ID_1234
  feature2:
    - DEV_USER_ID_5678
stage:
  feature:1
    - STAGE_USER_ID1234
prod:
  feature:1
    - PROD_USER_ID1234
```
