### PR TITLE
Initial work to add database to featurecop

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,5 @@
+exit
+::FeatureCop::UserList.new
+::FeatureCop::UserList.first
+::FeatureCop::UserList
+::FeatureCop.UserList

--- a/feature_cop.gemspec
+++ b/feature_cop.gemspec
@@ -25,4 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.9"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_development_dependency "sqlite3"
+  spec.add_development_dependency "rails"
+  spec.add_development_dependency "byebug"
 end

--- a/lib/feature_cop.rb
+++ b/lib/feature_cop.rb
@@ -10,7 +10,8 @@ require "feature_cop/toggle"
 require "json"
 require "yaml"
 
-
+require "generators/migrations"
+require "feature_cop/models/user_list"
 
 module FeatureCop
   include FeatureCop::Whitelist
@@ -18,42 +19,53 @@ module FeatureCop
   include FeatureCop::Sampling
   include FeatureCop::Toggle
 
-  def self.allows?(feature, identifier = nil, options = {})
-    feature_status = ENV["#{feature.to_s.upcase}"]
-    return false if feature_status.nil? 
-    self.method(feature_status.downcase).call(feature.to_s, identifier.to_s, options)
-  end
-
-  def self.env
-    @env ||= ENV["RAILS_ENV"] || ENV["RACK_ENV"] || ENV["APP_ENV"] || ENV["APP_ENV"] || "development"
-  end
-
-  def self.features
-    @features ||= self.set_features
-  end
-
-  def self.reset_features
-    @features = self.set_features
-  end
-
-  def self.set_features
-    features = {}
-    ENV.each_pair do |key, value|
-      features[key] = value if key.end_with?("_FEATURE")
+  class << self
+    def allows?(feature, identifier = nil, options = {})
+      feature_status = ENV["#{feature.to_s.upcase}"]
+      return false if feature_status.nil? 
+      self.method(feature_status.downcase).call(feature.to_s, identifier.to_s, options)
     end
-    return features
-  end
 
-  def self.as_json(identifier = nil)
-    feature_set = {}
-    features.each_pair do |feature, setting|
-      feature_set[feature.downcase.camelize(:lower)] = self.method(setting.downcase).call(feature, identifier)
+    def env
+      @env ||= ENV["RAILS_ENV"] || ENV["RACK_ENV"] || ENV["APP_ENV"] || ENV["APP_ENV"] || "development"
     end
-    feature_set
-  end
 
-  def self.to_json(identifier = nil)
-    self.as_json(identifier).to_json
+    def features
+      @features ||= self.set_features
+    end
+
+    def reset_features
+      @features = self.set_features
+    end
+
+    def set_features
+      features = {}
+      ENV.each_pair do |key, value|
+        features[key] = value if key.end_with?("_FEATURE")
+      end
+      return features
+    end
+
+    def as_json(identifier = nil)
+      feature_set = {}
+      features.each_pair do |feature, setting|
+        feature_set[feature.downcase.camelize(:lower)] = self.method(setting.downcase).call(feature, identifier)
+      end
+      feature_set
+    end
+
+    def to_json(identifier = nil)
+      self.as_json(identifier).to_json
+    end
+
+    def load_database
+      black = Blacklist.from_yaml
+      white = Whitelist.from_yaml
+
+      byebug
+      UserList.create(black)
+      Userlist.create(white)
+    end
   end
 end
 

--- a/lib/feature_cop/blacklist.rb
+++ b/lib/feature_cop/blacklist.rb
@@ -17,6 +17,7 @@ module FeatureCop
         raise "#{file} not found!" unless ::File.exist?(absolute_path)
         self.blacklist = ::YAML.load_file(absolute_path)[env]
       end
+      alias :from_yaml :blacklist_from_yaml
 
       def all_except_blacklist(feature, identifier, options = {})
         return true if blacklist.nil?

--- a/lib/feature_cop/models/user_list.rb
+++ b/lib/feature_cop/models/user_list.rb
@@ -1,0 +1,38 @@
+require "active_support/core_ext"
+
+module FeatureCop
+  class UserList < ActiveRecord::Base
+    self.table_name = :user_list # was defaulting to user_lists
+
+    enum list: [:disabled, :whitelist, :blacklist]
+
+    scope :disabled,  -> { where( list: 0) }
+    scope :whitelist, -> { where( list: 1) }
+    scope :blacklist, -> { where( list: 2) }
+
+    class << self
+      alias_method :white, :whitelist
+      alias_method :black, :blacklist
+      
+      def blacklist_ids
+        black.pluck(:identifier)
+      end
+
+      def whitelist_ids
+        white.pluck(:identifier)
+      end
+    end
+
+    def blacklist!
+      update!(:list => :blacklist)
+    end
+
+    def whitelist!
+      update!(:list => :whitelist)
+    end
+
+    def disable!
+      update!(:list => :disabled)
+    end
+  end
+end

--- a/lib/feature_cop/version.rb
+++ b/lib/feature_cop/version.rb
@@ -1,3 +1,3 @@
 module FeatureCop
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/lib/generators/migrations.rb
+++ b/lib/generators/migrations.rb
@@ -1,0 +1,27 @@
+require "rails/generators"
+require "rails/generators/active_record"
+
+module Featurecop
+  class MigrationsGenerator < ::Rails::Generators::Base
+    include ::Rails::Generators::Migration
+    desc "Writes migration(s) needed for featurecop DB."
+
+    source_root File.expand_path("../migrations", __FILE__)
+
+    def create_migration_file
+      write_migration("create_user_list_table")
+    end
+
+    def self.next_migration_number(directory)
+      ::ActiveRecord::Generators::Base.next_migration_number(directory)
+    end
+
+    private
+
+    def write_migration(file_name)
+      directory = File.expand_path("db/migrate")
+      migration_template "#{file_name}.rb", "db/migrate/#{file_name}.rb"
+    end
+
+  end
+end

--- a/lib/generators/migrations/create_user_list_table.rb
+++ b/lib/generators/migrations/create_user_list_table.rb
@@ -1,0 +1,12 @@
+class CreateUserListTable < ActiveRecord::Migration
+  
+  def change
+    create_table :user_list do |t|
+      t.string  :feature,    :null => false # MyFeatureX
+      t.string  :identifier, :null => false # Usr-123
+      t.integer :list,       :null => false , :default => 0 # enum
+      t.timestamps
+    end
+  end
+end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,11 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+require "rails"
+require "rails/generators"
+require "rails/generators/active_record"
+
 require 'feature_cop'
 require 'securerandom'
 
 require 'minitest/autorun'
+require 'byebug'

--- a/test/user_list_test.rb
+++ b/test/user_list_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class UserListTest < Minitest::Test
+
+  def test_user_list_initialize
+    
+  end
+
+end


### PR DESCRIPTION
The problem with whitelist/blacklist is that you have to update the .yml files to make changes, which defeats the purpose of having a accessible feature that you can change without deploying (credit to Dennis). Making changes requires deploying, which is annoying.

Having a simple db of whitelist and blacklist allows command line changes without deploying code.

The use of the yml files would be only to setup the initial state of whitelisted and blacklisted users which can be shared across applications.